### PR TITLE
minor updates

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
@@ -17,9 +17,10 @@
 
 package org.apache.spark.mllib.evaluation
 
+import org.scalatest.FunSuite
+
 import org.apache.spark.mllib.linalg.Matrices
 import org.apache.spark.mllib.util.LocalSparkContext
-import org.scalatest.FunSuite
 
 class MulticlassMetricsSuite extends FunSuite with LocalSparkContext {
   test("Multiclass evaluation metrics") {


### PR DESCRIPTION
@avulanov I made some minor updates:
1. change confusions to key by (label, prediction), which is more common
2. reuse `n`
3. organize imports
